### PR TITLE
remove re-focus function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 - [Open a `tabpanel` from URL hash](https://github.com/scottaohara/a11y_tab_widget/issues/8).
 - Additional documentation about UX for Tab Widgets.
 
+## [2.1.4] - 2021-09-20
+### Removed
+Removed function to re-focus active tab, which was originally put in place to work around buggy JAWS behavior. The function was causing VO focus to constantly re-shift to active tab when attempting to swipe through tabs, due to changes in how VO focus works on iOS.
+
 ## [2.1.3] - 2019-08-06
 ### Added
 - Open tabpanel from URL hash via [PR 18](https://github.com/scottaohara/a11y_tab_widget/pull/18).

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ var util = {
    * different subsections of a document.
    *
    * Author: Scott O'Hara
-   * Version: 2.1.3
+   * Version: 2.1.4
    * License: https://github.com/scottaohara/a11y_tab_widget/blob/master/LICENSE
    */
   var ARIAtabsOptions = {
@@ -453,11 +453,13 @@ var util = {
      * inactive tag (which will receive focus), JAWS will announce
      * to use the Space key to activate, but nothing will happen.
      */
-    var checkYoSelf = function ( index ) {
-      if ( index !== activeIndex ) {
-        focusActiveTab();
-      }
-    }; // checkYoSelf()
+    // sept19-2021 - commenting this out as it causes focus issues with 
+    // iOS + VoiceOver.  
+    // var checkYoSelf = function ( index ) {
+    //  if ( index !== activeIndex ) {
+    //    focusActiveTab();
+    //  }
+    // }; // checkYoSelf()
 
 
     var deactivateTabs = function () {


### PR DESCRIPTION
remove function to re-focus active tab.  is causing VO focus to constantly re-shift to active tab due to changes in how VO focus works on iOS.